### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,9 @@ module.exports = {
         for (let i = 0; i < len; i++) {
             const part = path[i];
 
-            if (i === len - 1) {
+            if (isPrototypePolluted(part)) {
+                continue;
+            } else if (i === len - 1) {
                 obj[part] = val;
             } else {
                 const nextType = typeof path[i + 1];
@@ -82,4 +84,8 @@ module.exports = {
 
 function isValidObject(val) {
     return (val !== null && typeof val === 'object') || Array.isArray(val);
+}
+
+function isPrototypePolluted(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -198,6 +198,11 @@ describe('auger.set', function () {
         expect(auger.set({}, ['a', 0])).toStrictEqual({ a: [undefined] });
         expect(auger.set({ a: { b: 'c' } }, ['a', 'b'])).toStrictEqual({ a: { b: undefined } });
     });
+
+    test('should not set magic attribute values', function () {
+        expect(auger.set({}, ['__proto__', 'polluted'], true)).toStrictEqual({ polluted: true });
+        expect({}.polluted).toBe(undefined);
+    });
     
     test('should set as object or array depending on if the value is a string or number', function () {
         expect(auger.set({}, ['a', 0], 'c')).toStrictEqual({ a: ['c'] });


### PR DESCRIPTION
### :bar_chart: Metadata *

`object-auger` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-auger

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var objectAuger = require("object-auger")
var obj = {}
console.log("Before : " + {}.polluted);
objectAuger.set(obj,["__proto__","polluted"],"Yes! Its Polluted");
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i object-auger # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105167142-578eac00-5b3e-11eb-920d-edcab2b2032e.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
